### PR TITLE
Add OpenAI content generation pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+output

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Content Generation Pipeline
+
+This project demonstrates a simple content generation pipeline using the OpenAI API in Node.js/TypeScript.
+It generates textual content for a configurable entity type using GPT models and creates images with DALL-E 3.
+
+## Setup
+
+1. Ensure Node.js 18+ is installed.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Set the `OPENAI_API_KEY` environment variable with your OpenAI API key.
+
+## Usage
+
+To run the included example pipeline:
+
+```bash
+npx ts-node src/pipeline.ts
+```
+
+This will generate a set of entities, write them to `output/<entity>.yaml`, and download images to `output/images/`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "contentgenerationpipeline",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node build/pipeline.js",
+    "test": "tsc --noEmit"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/EntityType.ts
+++ b/src/EntityType.ts
@@ -1,0 +1,27 @@
+export interface EntityTypeConfig {
+  name: string;
+  description: string;
+  fields: string[];
+  examples?: string;
+  image: {
+    n: number; // number of images per entity
+    size?: string; // e.g., "1024x1024"
+    style?: string; // e.g., "vivid" or "natural"
+  };
+}
+
+export class EntityType {
+  name: string;
+  description: string;
+  fields: string[];
+  examples?: string;
+  image: { n: number; size?: string; style?: string };
+
+  constructor(cfg: EntityTypeConfig) {
+    this.name = cfg.name;
+    this.description = cfg.description;
+    this.fields = cfg.fields;
+    this.examples = cfg.examples;
+    this.image = cfg.image;
+  }
+}

--- a/src/openaiClient.ts
+++ b/src/openaiClient.ts
@@ -1,0 +1,62 @@
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface GenerationOptions {
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export class OpenAIClient {
+  private apiKey: string;
+  private baseUrl: string;
+  constructor(apiKey?: string, baseUrl = 'https://api.openai.com/v1') {
+    this.apiKey = apiKey || process.env.OPENAI_API_KEY || '';
+    this.baseUrl = baseUrl;
+  }
+
+  async chat(messages: ChatMessage[], options: GenerationOptions = {}): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: options.model || 'gpt-4o',
+        messages,
+        temperature: options.temperature ?? 1,
+        max_tokens: options.max_tokens ?? 800,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`OpenAI chat error: ${response.status} ${await response.text()}`);
+    }
+    const json = (await response.json()) as any;
+    return json.choices[0].message.content as string;
+  }
+
+  async createImage(prompt: string, n = 1, size = '1024x1024', style = 'vivid'): Promise<{ url: string }[]> {
+    const response = await fetch(`${this.baseUrl}/images/generations`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'dall-e-3',
+        prompt,
+        n,
+        size,
+        style,
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`OpenAI image error: ${response.status} ${await response.text()}`);
+    }
+    const json = (await response.json()) as any;
+    return json.data as { url: string }[];
+  }
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,76 @@
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { EntityType } from './EntityType';
+import { OpenAIClient } from './openaiClient';
+import { toYAML } from './yamlUtil';
+
+export interface PipelineConfig {
+  outputDir: string;
+  entityCount: number;
+  entityType: EntityType;
+}
+
+export async function runPipeline(cfg: PipelineConfig, client: OpenAIClient) {
+  mkdirSync(cfg.outputDir, { recursive: true });
+  const imagesDir = join(cfg.outputDir, 'images');
+  mkdirSync(imagesDir, { recursive: true });
+
+  const fields = cfg.entityType.fields.map(f => `- ${f}`).join('\n');
+  let examplesSection = '';
+  if (cfg.entityType.examples) {
+    examplesSection = `Here are some examples:\n${cfg.entityType.examples}`;
+  }
+  const prompt = `You are generating ${cfg.entityType.name} data. Each entity has the following fields:\n${fields}\n${examplesSection}\nGenerate ${cfg.entityCount} items in JSON format.`;
+
+  const completion = await client.chat([
+    { role: 'system', content: 'You are a content generation assistant.' },
+    { role: 'user', content: prompt },
+  ]);
+
+  const doc = JSON.parse(completion.trim());
+
+  const yamlPath = join(cfg.outputDir, `${cfg.entityType.name.toLowerCase()}.yaml`);
+
+  let idx = 0;
+  for (const item of doc) {
+    const baseName = `${cfg.entityType.name.toLowerCase()}_${idx}`;
+    const imagePrompt = item.image_description || `Image for ${item.name}`;
+    const images = await client.createImage(
+      imagePrompt,
+      cfg.entityType.image.n,
+      cfg.entityType.image.size,
+      cfg.entityType.image.style,
+    );
+    images.forEach((img, i) => {
+      const fname = `${baseName}_${i}.png`;
+      const dest = join(imagesDir, fname);
+      fetch(img.url)
+        .then((res: any) => res.arrayBuffer())
+        .then((buff: ArrayBuffer) => {
+          writeFileSync(dest, Buffer.from(buff));
+        });
+      item[`${cfg.entityType.image.n > 1 ? 'image_names' : 'image_name'}`] ||= [];
+      item[`${cfg.entityType.image.n > 1 ? 'image_names' : 'image_name'}`].push(fname);
+    });
+    idx++;
+  }
+
+  writeFileSync(yamlPath, toYAML(doc), 'utf-8');
+}
+
+if (require.main === module) {
+  const entityType = new EntityType({
+    name: 'Card',
+    description: 'A card entity for a card game.',
+    fields: ['name', 'effect', 'image_description', 'image_name'],
+    examples: '- name: Fireball\n  effect: Deal 3 damage to all enemies\n  image_description: A blazing fireball',
+    image: { n: 3, size: '1024x1024', style: 'vivid' },
+  });
+  const cfg: PipelineConfig = {
+    outputDir: './output',
+    entityCount: 5,
+    entityType,
+  };
+  const client = new OpenAIClient();
+  runPipeline(cfg, client).catch(err => console.error(err));
+}

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -1,0 +1,15 @@
+declare var process: any;
+declare var Buffer: any;
+declare var fetch: any;
+declare var require: any;
+declare var module: any;
+declare var console: any;
+
+declare module 'fs' {
+  export function writeFileSync(path: string, data: any, opts?: any): void;
+  export function mkdirSync(path: string, opts?: any): void;
+}
+
+declare module 'path' {
+  export function join(...parts: any[]): string;
+}

--- a/src/yamlUtil.ts
+++ b/src/yamlUtil.ts
@@ -1,0 +1,31 @@
+export function toYAML(value: any, indent = 0): string {
+  const pad = '  '.repeat(indent);
+  if (Array.isArray(value)) {
+    return value.map(v => `${pad}- ${format(v, indent + 1)}`).join('\n');
+  } else if (value && typeof value === 'object') {
+    return Object.entries(value)
+      .map(([k, v]) => {
+        const val = format(v, indent + 1);
+        if (isComplex(v)) {
+          return `${pad}${k}:\n${val}`;
+        }
+        return `${pad}${k}: ${val}`;
+      })
+      .join('\n');
+  }
+  return `${pad}${format(value, indent)}`;
+}
+
+function format(v: any, indent: number): string {
+  if (Array.isArray(v) || (v && typeof v === 'object')) {
+    return toYAML(v, indent);
+  }
+  if (typeof v === 'string') {
+    return JSON.stringify(v);
+  }
+  return String(v);
+}
+
+function isComplex(v: any): boolean {
+  return Array.isArray(v) || (v && typeof v === 'object');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,114 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "libReplacement": true,                           /* Enable lib replacement. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "build",
+    "lib": ["es2021"],
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
## Summary
- set up TypeScript project
- implement `EntityType` model and OpenAI client
- implement generation pipeline with simple YAML output
- add minimal type declarations
- include example usage and README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b698edb90833380f1ce848ae129ff