### PR TITLE
Add CLI for generating cards and buffs

### DIFF
--- a/CLASSES.txt
+++ b/CLASSES.txt
@@ -1,0 +1,4 @@
+Archon
+Blackhand
+Cog
+Diabolist

--- a/CLASS_DESCRIPTIONS.txt
+++ b/CLASS_DESCRIPTIONS.txt
@@ -1,0 +1,5 @@
+Archon - Disciplined officers and inspirational leaders who command squads with unwavering resolve. Their cards focus on Pluck, Intimidation and tactical advantages that rally allies and harden defenses.
+Blackhand - Flamethrower zealots and pyromaniacs clad in protective gear. Their mechanics revolve around spreading Burning, using Smog and explosive finishers to fuel high damage.
+Cog - Inventors and tinkerers wielding pneumatic weapons and mechanical contraptions. Many cards create or replicate other cards and convert Venture and Ashes into raw power or improved gear.
+Diabolist - Occultists who bargain with dark forces, channeling Blood and Cursed energies. Their abilities involve sacrifice, eldritch smoke and high-risk spells that grow stronger with blood magic.
+

--- a/README.md
+++ b/README.md
@@ -14,10 +14,23 @@ It generates textual content for a configurable entity type using GPT models and
 
 ## Usage
 
-To run the included example pipeline:
+The generator consumes several input text files stored in the repository root:
+
+- `CARDS.txt` – example cards grouped by class
+- `BUFF_EXAMPLES.txt` – sample buff descriptions
+- `CLASSES.txt` – the list of class names
+- `CLASS_DESCRIPTIONS.txt` – brief summaries of each class drawn from the card examples
+
+You can run the generator through the CLI which exposes several commands:
 
 ```bash
-npx ts-node src/pipeline.ts
+npx ts-node src/cli.ts <command> [--count N] [--output DIR]
 ```
 
-This will generate a set of entities, write them to `output/<entity>.yaml`, and download images to `output/images/`.
+Available commands are:
+
+- `cards` – generate new cards complete with image prompts and cheeky commentary.
+- `persona-buffs` – generate new persona trait buffs.
+- `describe-classes` – generate aesthetic/mechanical descriptions for each class.
+
+Output files are written to the chosen directory (default `./output`) with images saved under `images/` when applicable.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/pipeline.js",
+    "cli": "node build/cli.js",
     "test": "tsc --noEmit"
   },
   "keywords": [],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { EntityType } from './EntityType';
+import { OpenAIClient } from './openaiClient';
+import { runPipeline } from './pipeline';
+
+function load(file: string): string {
+  const p = join(__dirname, '..', file);
+  return readFileSync(p, 'utf-8');
+}
+
+interface Options {
+  count: number;
+  output: string;
+}
+
+function parseOptions(args: string[]): Options {
+  const opts: Options = { count: 5, output: './output' };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--count' && args[i + 1]) {
+      opts.count = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i] === '--output' && args[i + 1]) {
+      opts.output = args[i + 1];
+      i++;
+    }
+  }
+  return opts;
+}
+
+async function generateCards(opts: Options) {
+  const cardExamples = load('CARDS.txt');
+  const buffExamples = load('BUFF_EXAMPLES.txt');
+  const classes = load('CLASSES.txt');
+
+  const context = `Here is a list of existing cards:\n${cardExamples}\n\nBuff examples for terminology:\n${buffExamples}\n\nAvailable classes:\n${classes}\n\nEach generated card must include:\n- a 'name'\n- a 'description'\n- a 'class' from the list above or the word 'Cargo'\n- if the class is Cargo, include numeric 'HellSellValue'\n- an array 'commentaries' with three cheeky one-sentence remarks\n- an array 'image_descriptions' containing three different prompts for illustrations.`;
+
+  const entityType = new EntityType({
+    name: 'Card',
+    description: 'A playable card.',
+    fields: ['name', 'description', 'class', 'HellSellValue', 'commentaries', 'image_descriptions'],
+    image: { n: 3, size: '1024x1024', style: 'vivid' },
+  });
+
+  const client = new OpenAIClient();
+  await runPipeline({ outputDir: opts.output, entityCount: opts.count, entityType, additionalContext: context }, client);
+}
+
+async function generatePersonaBuffs(opts: Options) {
+  const buffExamples = load('BUFF_EXAMPLES.txt');
+  const context = `Persona buffs are permanent character traits. Use the following examples for inspiration:\n${buffExamples}`;
+
+  const entityType = new EntityType({
+    name: 'PersonaBuff',
+    description: 'A permanent trait possessed by a soldier.',
+    fields: ['name', 'description'],
+    image: { n: 0 },
+  });
+
+  const client = new OpenAIClient();
+  await runPipeline({ outputDir: opts.output, entityCount: opts.count, entityType, additionalContext: context }, client);
+}
+
+async function describeClasses(opts: Options) {
+  const cardExamples = load('CARDS.txt');
+  const classList = load('CLASSES.txt').split(/\r?\n/).filter(Boolean);
+  const context = `Using the following card examples, describe the aesthetics and mechanics embodied by each class. Generate one item per class name provided.\nClasses:\n${classList.map(c => '- ' + c).join('\n')}\n\nCard examples:\n${cardExamples}`;
+
+  const entityType = new EntityType({
+    name: 'ClassDescription',
+    description: 'A description of a game class.',
+    fields: ['name', 'aesthetics', 'mechanics'],
+    image: { n: 0 },
+  });
+
+  const client = new OpenAIClient();
+  await runPipeline({ outputDir: opts.output, entityCount: classList.length, entityType, additionalContext: context }, client);
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+  const opts = parseOptions(rest);
+
+  if (command === 'cards') {
+    await generateCards(opts);
+  } else if (command === 'persona-buffs') {
+    await generatePersonaBuffs(opts);
+  } else if (command === 'describe-classes') {
+    await describeClasses(opts);
+  } else {
+    console.error('Commands: cards | persona-buffs | describe-classes');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -8,6 +8,7 @@ export interface PipelineConfig {
   outputDir: string;
   entityCount: number;
   entityType: EntityType;
+  additionalContext?: string;
 }
 
 export async function runPipeline(cfg: PipelineConfig, client: OpenAIClient) {
@@ -20,7 +21,11 @@ export async function runPipeline(cfg: PipelineConfig, client: OpenAIClient) {
   if (cfg.entityType.examples) {
     examplesSection = `Here are some examples:\n${cfg.entityType.examples}`;
   }
-  const prompt = `You are generating ${cfg.entityType.name} data. Each entity has the following fields:\n${fields}\n${examplesSection}\nGenerate ${cfg.entityCount} items in JSON format.`;
+  let prompt = `You are generating ${cfg.entityType.name} data. Each entity has the following fields:\n${fields}\n${examplesSection}`;
+  if (cfg.additionalContext) {
+    prompt += `\n${cfg.additionalContext}`;
+  }
+  prompt += `\nGenerate ${cfg.entityCount} items in JSON format.`;
 
   const completion = await client.chat([
     { role: 'system', content: 'You are a content generation assistant.' },
@@ -34,24 +39,27 @@ export async function runPipeline(cfg: PipelineConfig, client: OpenAIClient) {
   let idx = 0;
   for (const item of doc) {
     const baseName = `${cfg.entityType.name.toLowerCase()}_${idx}`;
-    const imagePrompt = item.image_description || `Image for ${item.name}`;
-    const images = await client.createImage(
-      imagePrompt,
-      cfg.entityType.image.n,
-      cfg.entityType.image.size,
-      cfg.entityType.image.style,
-    );
-    images.forEach((img, i) => {
-      const fname = `${baseName}_${i}.png`;
-      const dest = join(imagesDir, fname);
-      fetch(img.url)
-        .then((res: any) => res.arrayBuffer())
-        .then((buff: ArrayBuffer) => {
-          writeFileSync(dest, Buffer.from(buff));
-        });
-      item[`${cfg.entityType.image.n > 1 ? 'image_names' : 'image_name'}`] ||= [];
-      item[`${cfg.entityType.image.n > 1 ? 'image_names' : 'image_name'}`].push(fname);
-    });
+    if (cfg.entityType.image.n > 0) {
+      const imagePrompt = item.image_description || `Image for ${item.name}`;
+      const images = await client.createImage(
+        imagePrompt,
+        cfg.entityType.image.n,
+        cfg.entityType.image.size,
+        cfg.entityType.image.style,
+      );
+      images.forEach((img, i) => {
+        const fname = `${baseName}_${i}.png`;
+        const dest = join(imagesDir, fname);
+        fetch(img.url)
+          .then((res: any) => res.arrayBuffer())
+          .then((buff: ArrayBuffer) => {
+            writeFileSync(dest, Buffer.from(buff));
+          });
+        const key = cfg.entityType.image.n > 1 ? 'image_names' : 'image_name';
+        item[key] ||= [];
+        item[key].push(fname);
+      });
+    }
     idx++;
   }
 

--- a/src/types/node.d.ts
+++ b/src/types/node.d.ts
@@ -4,8 +4,10 @@ declare var fetch: any;
 declare var require: any;
 declare var module: any;
 declare var console: any;
+declare var __dirname: string;
 
 declare module 'fs' {
+  export function readFileSync(path: string, opts?: any): string;
   export function writeFileSync(path: string, data: any, opts?: any): void;
   export function mkdirSync(path: string, opts?: any): void;
 }


### PR DESCRIPTION
## Summary
- implement simple CLI to generate cards, persona buffs and class descriptions
- allow extra prompt context and optional images in pipeline
- provide minimal node typings and add CLASSES.txt
- update README with CLI usage and explain the input files
- add class summaries in `CLASS_DESCRIPTIONS.txt`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68504e447b508333ad56ae04d3fe0128